### PR TITLE
Make librrd unsurprising for RubyGems users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 pkg
+
+# Generated when building the gem during development
+Makefile
+RRD.so
+main.o
+mkmf.log
+test.png
+test.rrd

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following systems, RRDtool versions and Ruby versions  have been tested.
 Make sure you have the development package of `librrd` installed.
 (like `librrd-dev` on Debian/Ubuntu) Then you can just `gem install`.
 
-        gem install librrd
+    gem install librrd
 
 # Developing
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Make sure you have the development package of `librrd` installed.
 
         gem install librrd
 
+# Developing
+
+Build the C extension:
+
+    ruby ext/librrd/extconf.rb
+    make
+
+Run the tests:
+
+    ruby test.rb
+
 # Contribute
 
 Please test the gem on different systems with different RRDtool versions

--- a/lib/librrd.rb
+++ b/lib/librrd.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'RRD'
+
+LibRRD = RRD

--- a/test.rb
+++ b/test.rb
@@ -16,7 +16,7 @@ RRD.create(
     rrd,
     "--start", "#{start_time - 1}",
     "--step", "300",
-	"DS:a:GAUGE:600:U:U",
+    "DS:a:GAUGE:600:U:U",
     "DS:b:GAUGE:600:U:U",
     "RRA:AVERAGE:0.5:1:300")
 puts
@@ -35,10 +35,10 @@ puts
 puts "generating graph #{name}.png"
 RRD.graph(
    "#{name}.png",
-    "--title", " RubyRRD Demo", 
+    "--title", " RubyRRD Demo",
     "--start", "#{start_time+3600}",
     "--end", "start + 1000 min",
-    "--interlace", 
+    "--interlace",
     "--imgformat", "PNG",
     "--width=450",
     "DEF:a=#{rrd}:a:AVERAGE",
@@ -60,9 +60,9 @@ puts
 if RRD.respond_to?(:xport)
   puts "xporting data from #{rrd}"
   (fstart,fend,step,col,legend,data)=RRD.xport(
-    "--start", start_time.to_s, 
-    "--end", (start_time + 300 * 300).to_s, 
-    "--step", 10.to_s, 
+    "--start", start_time.to_s,
+    "--end", (start_time + 300 * 300).to_s,
+    "--step", 10.to_s,
     "DEF:A=#{rrd}:a:AVERAGE",
     "DEF:B=#{rrd}:b:AVERAGE",
     "XPORT:A:a",

--- a/test.rb
+++ b/test.rb
@@ -74,3 +74,24 @@ end
 
 print "This script has created #{name}.png in the current directory\n";
 print "This demonstrates the use of the TIME and % RPN operators\n";
+
+# RubyGems users expect when they install a gem that:
+#
+#   "gem name" == "name they require" == "name of object in global namespace".
+#
+# Alias RRD to LibRRD, so backwards compatibility is retained, but RubyGems
+# users aren't surprised.
+#
+puts
+$: << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
+require 'librrd'
+
+if Object.const_defined?(:"LibRRD")
+  if %w(fetch dump graph update).all? {|m| LibRRD.methods.include?(m) }
+    puts "Rubygems compatibility layer present"
+  else
+    puts "Rubygems compatibility layer present, but methods not available"
+  end
+else
+  puts "Rubygems compatibility layer not present"
+end


### PR DESCRIPTION
Created `lib/librrd.rb`, and in it `LibRRD = RRD`. 
