### PR TITLE
librrd fails to build on Ubuntu

### DIFF
--- a/ext/librrd/extconf.rb
+++ b/ext/librrd/extconf.rb
@@ -13,6 +13,8 @@ end
 
 dir_config("rrd")
 
+$CFLAGS += " -Wno-error=format-security"
+
 # Try to detect the librrd version.
 # Please adjust if needed and open an issue on github
 # or submit a pull request. Thanks!


### PR DESCRIPTION
When building on Ubuntu 13.04, following error shows:

```
% sudo gem install librrd
Building native extensions.  This could take a while...
ERROR:  Error installing librrd:
    ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
checking for rrd_flushcached() in -lrrd... yes
creating Makefile

make
compiling ./1.4/main.c
./1.4/main.c: In function ‘string_arr_new’:
./1.4/main.c:60:22: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘long int’ [-Wformat]
./1.4/main.c:60:22: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘int’ [-Wformat]
./1.4/main.c: In function ‘rrd_call’:
./1.4/main.c:102:5: error: format not a string literal and no format arguments [-Werror=format-security]
./1.4/main.c: In function ‘rb_rrd_infocall’:
./1.4/main.c:170:5: error: format not a string literal and no format arguments [-Werror=format-security]
./1.4/main.c: In function ‘rb_rrd_fetch’:
./1.4/main.c:246:5: error: format not a string literal and no format arguments [-Werror=format-security]
./1.4/main.c: In function ‘rb_rrd_graph’:
./1.4/main.c:291:5: error: format not a string literal and no format arguments [-Werror=format-security]
./1.4/main.c: In function ‘rb_rrd_last’:
./1.4/main.c:319:5: error: format not a string literal and no format arguments [-Werror=format-security]
./1.4/main.c: In function ‘rb_rrd_xport’:
./1.4/main.c:340:5: error: format not a string literal and no format arguments [-Werror=format-security]
cc1: some warnings being treated as errors
make: *** [main.o] Błąd 1


Gem files will remain installed in /var/lib/gems/1.9.1/gems/librrd-1.0.3 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/librrd-1.0.3/ext/librrd/gem_make.out
```

Manual page gcc(1):

```
NOTE: In Ubuntu 8.10 and later versions this option is enabled by default for C, C++, ObjC, ObjC++.
           To disable, use -Wno-format-security, or disable all format warnings with -Wformat=0.  To make format
           security warnings fatal, specify -Werror=format-security.
```

Adding override to $CFLAGS did the trick. With this flag, the gem build successfully.
